### PR TITLE
Fix for grouphasnoroleexception

### DIFF
--- a/grassroot-services/src/main/java/za/org/grassroot/services/AsyncRoleManager.java
+++ b/grassroot-services/src/main/java/za/org/grassroot/services/AsyncRoleManager.java
@@ -110,6 +110,9 @@ public class AsyncRoleManager implements AsyncRoleService {
 
         Role role = fetchGroupRole(roleName, group.getId());
         addingToUser = flushUserRolesInGroup(addingToUser, group.getId());
+        if(role==null){
+            group.setGroupRoles(roleManagementService.createGroupRoles(group.getId(), group.getGroupName()));
+         }
 
         if (role == null) { throw new GroupHasNoRolesException(); }
 

--- a/grassroot-webapp/src/main/java/za/org/grassroot/webapp/util/USSDGroupUtil.java
+++ b/grassroot-webapp/src/main/java/za/org/grassroot/webapp/util/USSDGroupUtil.java
@@ -121,7 +121,7 @@ public class USSDGroupUtil extends USSDUtil {
         USSDMenu menu = new USSDMenu(prompt);
         Page<Group> groupsPartOf = groupManager.getPageOfActiveGroups(user, pageNumber, PAGE_LENGTH);
         if (groupsPartOf.getTotalElements() == 1) {
-            menu = skipGroupSelection(user, section, groupsPartOf.iterator().next().getId());
+            menu = skipGroupSelection(user, section,urlForNewGroup, groupsPartOf.iterator().next().getId());
         } else {
             menu = addListOfGroupsToMenu(menu, urlForExistingGroups, groupsPartOf.getContent(), user);
             if (groupsPartOf.hasNext())
@@ -201,7 +201,7 @@ public class USSDGroupUtil extends USSDUtil {
         return menu;
     }
 
-    public USSDMenu skipGroupSelection(User sessionUser, USSDSection section, Long groupId) {
+    public USSDMenu skipGroupSelection(User sessionUser, USSDSection section, String urlForNewGroup, Long groupId) {
         USSDMenu menu = null;
         String nextUrl;
         switch (section) {
@@ -234,10 +234,13 @@ public class USSDGroupUtil extends USSDUtil {
                 menu.addMenuOption(groupMenuWithId(addMemberPrompt, groupId), getMessage(menuKey + addMemberPrompt, sessionUser));
                 menu.addMenuOption(groupMenuWithId(unsubscribePrompt, groupId), getMessage(menuKey + unsubscribePrompt, sessionUser));
                 menu.addMenuOption(groupMenuWithId(renameGroupPrompt, groupId), getMessage(menuKey + renameGroupPrompt, sessionUser));
-                if (groupManager.isGroupCreatedByUser(groupId, sessionUser))
+                if (groupManager.isGroupCreatedByUser(groupId, sessionUser)) {
                     menu.addMenuOption(groupMenuWithId(mergeGroupMenu, groupId), getMessage(menuKey + mergeGroupMenu, sessionUser));
-                if (groupManager.canUserMakeGroupInactive(sessionUser, groupId))
+                }
+                if (groupManager.canUserMakeGroupInactive(sessionUser, groupId)) {
                     menu.addMenuOption(groupMenuWithId(inactiveMenu, groupId), getMessage(menuKey + inactiveMenu, sessionUser));
+                }
+                menu.addMenuOption(urlForNewGroup, getMessage(groupKeyForMessages, "create", "option", sessionUser));
                 break;
             default:
                 break;


### PR DESCRIPTION
Modified ussdgrouputil - skipping group selection when user only belonged to one group was preventing the user from creating a new group., added a menu option to create a new group under manage groups.

Fixed hopefully a bug where adding a member to an old group was not possible due to not having roles set.